### PR TITLE
Explore campaigns (revised)

### DIFF
--- a/grasshopperfund/campaigns/models.py
+++ b/grasshopperfund/campaigns/models.py
@@ -33,11 +33,11 @@ class Campaign(models.Model):
         return url
 
     @property
-    def current_money(self) -> Decimal:
+    def current_money(self) -> float:
         '''
         get current money from sum of donation amounts
         '''
-        money = Decimal(0)
+        money = 0
         for donation in self.donations.all():
             money += donation.amount
         return money
@@ -69,7 +69,7 @@ class Campaign(models.Model):
         '''
         Returns a percentage of how much of the funding goal has been reached
         '''
-        return self.target_money / self.current_money
+        return (self.current_money / self.target_money) * 100
 
     @property
     def all_tags(self) -> list:

--- a/grasshopperfund/campaigns/views.py
+++ b/grasshopperfund/campaigns/views.py
@@ -168,10 +168,44 @@ def make_donation(request, pk):
 
 
 def browse_campaigns(request):
-    tags = Tag.objects.all()
+    '''
+    Browse campaigns based on selected tags
+    These tags are queried via OR statements.
+    '''
+    # check for selected tags from the query parameter
+    # should be a list of tag names
+    queried_tags = request.GET.getlist('tag', [])
 
+    # all existing tags
+    all_tags = Tag.objects.all()
+
+    # selected tags based on what was queried
+    selected_tags = all_tags
+
+    print(queried_tags)
+
+    # check to filter by tag
+    if len(queried_tags) > 0:
+
+        # create quieries
+        # filter is case insensitive
+        queries = [Q(name__icontains=tag_name) for tag_name in queried_tags]
+
+        # init the final query
+        final_query = queries.pop()
+
+        for query in queries:
+
+            # join queries via OR statement
+            final_query |= query
+
+        # execute the final query
+        selected_tags = all_tags.filter(final_query)
+
+    # campaigns are accessible from tags
     context = {
-        'tags': tags
+        'all_tags': all_tags,
+        'selected_tags': selected_tags,
     }
 
     return render(request, 'campaigns/browse_campaigns.html', context)

--- a/grasshopperfund/templates/campaigns/browse_campaigns.html
+++ b/grasshopperfund/templates/campaigns/browse_campaigns.html
@@ -35,13 +35,11 @@
               <img src="{{ campaign.image.url }}">
             </div>
             <div class="card-content">
-              {% for title, progress in progress_dict.items %}
-              {% if title == campaign.title %}
-                <div class="progress">
-                  <div class="determinate" style="width: {{ progress }}%"></div>
-                </div>
-                {% endif %}
-              {% endfor %}
+
+              <div class="progress">
+                <div class="determinate" style="width: {{ campaign.percent_funded }}%"></div>
+              </div>
+
               <span class="card-title">{{campaign.title}}</span>
               <p class="organization">by {{ campaign.organization.name }}</p>
               <span class="days-left"><i class="material-icons">access_time</i> {{campaign.days_left}} days left</span>

--- a/grasshopperfund/templates/campaigns/browse_campaigns.html
+++ b/grasshopperfund/templates/campaigns/browse_campaigns.html
@@ -7,8 +7,18 @@
 {% block styles %}
 <link rel='stylesheet' href="{% static 'css/users/explore.css' %}">
 
+<!-- Populate list of tags to filter by -->
+<div class = "col s2">
+  {% for tag in all_tags %}
 
-{% for tag in tags %}
+  <!-- filters are made by adding them as a query parameter -->
+   <a class="btn waves-effect waves-teal btn-flat" href="{% url 'browse-campaigns' %}?tag={{ tag.name | urlencode }}">
+       #{{ tag.name }}</a>
+  {% endfor %}
+</div>
+
+<!-- Populate list of campaigns for each tag -->
+{% for tag in selected_tags %}
   <br>
   <p> 
     <strong>{{tag.name}}</strong>

--- a/grasshopperfund/templates/main.html
+++ b/grasshopperfund/templates/main.html
@@ -36,7 +36,7 @@
             <a class="nav-link" href="{% url 'startsmart-home' %}">Home</a>
           </li>
           <li class="nav-item">
-              <a class="nav-link" href="{% url 'browse-organizations' %}">Explore</a>
+              <a class="nav-link" href="{% url 'browse-campaigns' %}">Explore</a>
           </li>
           <li>
             <form action="{% url 'search-campaign' %}" class="input-field" method="get">


### PR DESCRIPTION
This includes changes mentioned in #102

## The Explore page

![explore_demo](https://user-images.githubusercontent.com/35512278/101310106-d3d56600-3802-11eb-9c07-a140435f52e4.gif)


### Where to find it
The view (forgive me for the naming) is titled as  `browse-campaigns`. This was for consistency since there is a `browse-organizations` view. 

Likewise, the URL is `/campaigns/browse/`.

Likewise, the template is found @ `templates/campaigns/brwose_campaigns.html`.

You can find the implementation @ `campaigns/views.py`.

### How to use it

Going to the page shows all tags and their respective campaigns. Therefore, if a campaign has multiple tags, it is listed multiple times. The idea behind this implementation is that the user is interested in searching by tags. 

So how do you search by tag? You add the tag name to the URL parameter -- you can even add multiple tags. Ex:

```
/campaigns/browse/?tag=advertising&tag=bio
```

The search filters based off of tags whose name contains those strings. It query searches those strings joined on an OR condition (so name contains advertising OR bio). 

More info about how I implemented the filters:

* [Dynamically creating URL query parameters within a template](https://stackoverflow.com/questions/4591525/is-it-possible-to-pass-query-parameters-via-djangos-url-template-tag/22126770)
* [Dynamically creating a query made up of multiple filters joined via OR](https://stackoverflow.com/questions/852414/how-to-dynamically-compose-an-or-query-filter-in-django)

## Changes to existing behavior

**Database changes were made. I recommend that you delete your existing database and migrate**

* Progress bar no longer comes from dictionary. It now accessed via an attribute on each Campaign (vastly decreasing search time). No calculation in template necessary (how it should be 😊). 
* `Tag` now has attribute `all_campaigns` to access all campaigns associated with the tag
* Deleted the `campaigns` Many-to-Many field from `Tag`. Unnecessary as the back-reference is already specified in `Campaign`. Also, future associations (like for `Post`) should be done likewise -- via a back-reference in the respective model (not within `Tag`).

### Tags are now Pre-Populated

As per the new requirements, campaign creators can no longer create their own tags. I've hardcoded a placeholder list that populates the database via a migration (the migration is `tags/migrations/populate_tags.py`). In the future, this will be done via a CSV file. 

To populate your database with tags, simply migrate:

```
python manage.py migrate
```


@PeterOR2D2 let me know if u have any questions! You can merge this whenever ur ready. 

